### PR TITLE
Fix typescript declaration on the ponyfill

### DIFF
--- a/src/AggregateAbortController.ts
+++ b/src/AggregateAbortController.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import { AbortController, AbortSignal } from './abortcontroller-ponyfill'
 
 class NullSignal {}
@@ -16,6 +15,7 @@ export default class AggregateAbortController {
    *  will be treated as a null-signal, and this abortcontroller will no
    *  longer be abortable.
    */
+  //@ts-ignore
   addSignal(signal: AbortSignal = new NullSignal()): void {
     if (this.signal.aborted) {
       throw new Error('cannot add a signal, already aborted!')

--- a/src/abortcontroller-ponyfill.ts
+++ b/src/abortcontroller-ponyfill.ts
@@ -1,10 +1,23 @@
 /* eslint-disable */
-if (typeof AbortController === 'undefined') {
-  const {
-    AbortController,
-    AbortSignal,
-  } = require('abortcontroller-polyfill/dist/cjs-ponyfill')
-  module.exports = { AbortController, AbortSignal }
-} else {
-  module.exports = { AbortController, AbortSignal }
-}
+
+import  {
+    AbortController as ponyfillAbortController,
+    AbortSignal as ponyfillAbortSignal,
+} from 'abortcontroller-polyfill/dist/cjs-ponyfill'
+var getGlobal = function () {
+	// the only reliable means to get the global object is
+	// `Function('return this')()`
+	// However, this causes CSP violations in Chrome apps.
+	if (typeof self !== 'undefined') { return self; }
+	if (typeof window !== 'undefined') { return window; }
+	if (typeof global !== 'undefined') { return global; }
+	throw new Error('unable to locate global object');
+};
+
+//@ts-ignore
+let AbortController = typeof getGlobal().AbortController === 'undefined'?ponyfillAbortController:getGlobal().AbortController 
+//@ts-ignore
+let AbortSignal= typeof getGlobal().AbortController === 'undefined'?ponyfillAbortSignal: getGlobal().AbortSignal
+
+export { AbortController,AbortSignal}
+


### PR DESCRIPTION
The typescripting on the abortcontroller ponyfill was not compiling correctly and was silencing the error due to a ts-ignore on the import of the ponyfill in src/AbortablePromiseCache.ts

This rearranges some stuff to make that typescript build actually work. It represents the danger of ts-ignore causing compilation failures. Also forced to use a globalThis type thing to look for the existence of AbortController

Alerted to this by https://github.com/GMOD/tabix-js/issues/84

