### PR TITLE
Add failing test for caching failed stuff

### DIFF
--- a/src/AbortablePromiseCache.ts
+++ b/src/AbortablePromiseCache.ts
@@ -96,8 +96,7 @@ export default class AbortablePromiseCache<T, U> {
           newEntry.settled = true
 
           // if the fill throws an abort and is still in the cache, remove it
-          if (AbortablePromiseCache.isAbortException(exception))
-            this.evict(key, newEntry)
+          this.evict(key, newEntry)
         },
       )
       .catch(e => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -370,3 +370,18 @@ test('clear can delete two', async () => {
   expect(cache.has('foo')).toBe(false)
   expect(cache.has('bar')).toBe(false)
 })
+
+test('not caching errors', async () => {
+  let i = 0
+  const cache = new AbortablePromiseCache({
+    cache: new QuickLRU({ maxSize: 2 }),
+    async fill(data, { signal }) {
+      if (i++ === 0) {
+        throw new Error('first time')
+      } else return 42
+    },
+  })
+
+  await expect(cache.get('foo')).rejects.toEqual(new Error('first time'))
+  await expect(cache.get('foo')).resolves.toEqual(42)
+})


### PR DESCRIPTION
I think that abortable-promise-cache is caching failed requests

This adds a test and a proposed fix

Related to the overall goal of allowing track reloads