### PR TITLE
Status reporting

### DIFF
--- a/src/AbortablePromiseCache.ts
+++ b/src/AbortablePromiseCache.ts
@@ -78,10 +78,10 @@ export default class AbortablePromiseCache<T, U> {
   fill(key: string, data: T, signal?: AbortSignal, statusCallback?: Function) {
     const aborter = new AggregateAbortController()
     const statusReporter = new AggregateStatusReporter()
+    statusReporter.addCallback(statusCallback)
     const newEntry: Entry<U> = {
       aborter: aborter,
       promise: this.fillCallback(data, aborter.signal, (message: unknown) => {
-        console.log({ wtf: 'wtf' })
         statusReporter.callback(message)
       }),
       settled: false,
@@ -91,7 +91,6 @@ export default class AbortablePromiseCache<T, U> {
       },
     }
     newEntry.aborter.addSignal(signal)
-    newEntry.statusReporter.addCallback(statusCallback)
 
     // remove the fill from the cache when its abortcontroller fires, if still in there
     newEntry.aborter.signal.addEventListener('abort', () => {
@@ -178,7 +177,6 @@ export default class AbortablePromiseCache<T, U> {
       // request is in-flight, add this signal to its list of signals,
       // or if there is no signal, the aborter will become non-abortable
       cacheEntry.aborter.addSignal(signal)
-
       cacheEntry.statusReporter.addCallback(statusCallback)
 
       return AbortablePromiseCache.checkSinglePromise(

--- a/src/AbortablePromiseCache.ts
+++ b/src/AbortablePromiseCache.ts
@@ -1,5 +1,6 @@
 import { AbortSignal } from './abortcontroller-ponyfill'
 import AggregateAbortController from './AggregateAbortController'
+import AggregateStatusReporter from './AggregateStatusReporter'
 
 type Cache<U> = {
   delete: (key: string) => void
@@ -8,12 +9,17 @@ type Cache<U> = {
   set: (key: string, val: U) => void
   has: (key: string) => boolean
 }
-type FillCallback<T, U> = (data: T, signal?: AbortSignal) => Promise<U>
+type FillCallback<T, U> = (
+  data: T,
+  signal?: AbortSignal,
+  statusCallback?: Function,
+) => Promise<U>
 
 type Entry<U> = {
   aborter: AggregateAbortController
   settled: boolean
   readonly aborted: boolean
+  statusReporter: AggregateStatusReporter
   promise: Promise<U>
 }
 export default class AbortablePromiseCache<T, U> {
@@ -69,17 +75,23 @@ export default class AbortablePromiseCache<T, U> {
     if (this.cache.get(key) === entry) this.cache.delete(key)
   }
 
-  fill(key: string, data: T, signal?: AbortSignal) {
+  fill(key: string, data: T, signal?: AbortSignal, statusCallback?: Function) {
     const aborter = new AggregateAbortController()
+    const statusReporter = new AggregateStatusReporter()
     const newEntry: Entry<U> = {
       aborter: aborter,
-      promise: this.fillCallback(data, aborter.signal),
+      promise: this.fillCallback(data, aborter.signal, (message: unknown) => {
+        console.log({ wtf: 'wtf' })
+        statusReporter.callback(message)
+      }),
       settled: false,
+      statusReporter,
       get aborted() {
         return this.aborter.signal.aborted
       },
     }
     newEntry.aborter.addSignal(signal)
+    newEntry.statusReporter.addCallback(statusCallback)
 
     // remove the fill from the cache when its abortcontroller fires, if still in there
     newEntry.aborter.signal.addEventListener('abort', () => {
@@ -139,7 +151,12 @@ export default class AbortablePromiseCache<T, U> {
    * @param {any} data data passed as the first argument to the fill callback
    * @param {AbortSignal} [signal] optional AbortSignal object that aborts the request
    */
-  get(key: string, data: T, signal?: AbortSignal): Promise<U> {
+  get(
+    key: string,
+    data: T,
+    signal?: AbortSignal,
+    statusCallback?: Function,
+  ): Promise<U> {
     if (!signal && data instanceof AbortSignal)
       throw new TypeError(
         'second get argument appears to be an AbortSignal, perhaps you meant to pass `null` for the fill data?',
@@ -150,16 +167,19 @@ export default class AbortablePromiseCache<T, U> {
       if (cacheEntry.aborted) {
         // if it's aborted but has not realized it yet, evict it and redispatch
         this.evict(key, cacheEntry)
-        return this.get(key, data, signal)
+        return this.get(key, data, signal, statusCallback)
       }
 
-      if (cacheEntry.settled)
+      if (cacheEntry.settled) {
         // too late to abort, just return it
         return cacheEntry.promise
+      }
 
       // request is in-flight, add this signal to its list of signals,
       // or if there is no signal, the aborter will become non-abortable
       cacheEntry.aborter.addSignal(signal)
+
+      cacheEntry.statusReporter.addCallback(statusCallback)
 
       return AbortablePromiseCache.checkSinglePromise(
         cacheEntry.promise,
@@ -168,7 +188,7 @@ export default class AbortablePromiseCache<T, U> {
     }
 
     // if we got here, it is not in the cache. fill.
-    this.fill(key, data, signal)
+    this.fill(key, data, signal, statusCallback)
     return AbortablePromiseCache.checkSinglePromise(
       this.cache.get(key).promise,
       signal,

--- a/src/AbortablePromiseCache.ts
+++ b/src/AbortablePromiseCache.ts
@@ -146,9 +146,17 @@ export default class AbortablePromiseCache<T, U> {
   }
 
   /**
+   * Callback for getting status of the pending async
+   *
+   * @callback statusCallback
+   * @param {any} status, current status string or message object
+   */
+
+  /**
    * @param {any} key cache key to use for this request
    * @param {any} data data passed as the first argument to the fill callback
    * @param {AbortSignal} [signal] optional AbortSignal object that aborts the request
+   * @param {statusCallback} a callback to get the current status of a pending async operation
    */
   get(
     key: string,

--- a/src/AggregateStatusReporter.ts
+++ b/src/AggregateStatusReporter.ts
@@ -1,0 +1,15 @@
+export default class AggregateStatusReporter {
+  callbacks = new Set<Function>()
+
+  addCallback(callback: Function = () => {}): void {
+    console.log('wtf', callback.toString())
+    this.callbacks.add(callback)
+  }
+
+  callback(message: unknown) {
+    console.log({ message, c: this.callbacks })
+    this.callbacks.forEach(elt => {
+      elt(message)
+    })
+  }
+}

--- a/src/AggregateStatusReporter.ts
+++ b/src/AggregateStatusReporter.ts
@@ -6,7 +6,6 @@ export default class AggregateStatusReporter {
   }
 
   callback(message: unknown) {
-    console.log({ message, c: this.callbacks })
     this.callbacks.forEach(elt => {
       elt(message)
     })

--- a/src/AggregateStatusReporter.ts
+++ b/src/AggregateStatusReporter.ts
@@ -2,7 +2,6 @@ export default class AggregateStatusReporter {
   callbacks = new Set<Function>()
 
   addCallback(callback: Function = () => {}): void {
-    console.log('wtf', callback.toString())
     this.callbacks.add(callback)
   }
 

--- a/src/AggregateStatusReporter.ts
+++ b/src/AggregateStatusReporter.ts
@@ -1,11 +1,14 @@
 export default class AggregateStatusReporter {
   callbacks = new Set<Function>()
+  currentMessage: unknown
 
   addCallback(callback: Function = () => {}): void {
     this.callbacks.add(callback)
+    callback(this.currentMessage)
   }
 
   callback(message: unknown) {
+    this.currentMessage = message
     this.callbacks.forEach(elt => {
       elt(message)
     })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -376,6 +376,9 @@ test('not caching errors', async () => {
   const cache = new AbortablePromiseCache({
     cache: new QuickLRU({ maxSize: 2 }),
     async fill(data, { signal }) {
+      console.log('t1')
+      await delay(30)
+      console.log('t2')
       if (i++ === 0) {
         throw new Error('first time')
       } else return 42
@@ -383,5 +386,28 @@ test('not caching errors', async () => {
   })
 
   await expect(cache.get('foo')).rejects.toEqual(new Error('first time'))
-  await expect(cache.get('foo')).resolves.toEqual(42)
+  // await expect(cache.get('foo')).resolves.toEqual(42)
+})
+
+test('status callback', async () => {
+  const aborter1 = new AbortController()
+  const cache = new AbortablePromiseCache({
+    cache: new QuickLRU({ maxSize: 2 }),
+    async fill(data, signal, statusCallback) {
+      await delay(30)
+      console.log('here', data)
+      statusCallback('working...')
+      return 'success'
+    },
+  })
+
+  const s1 = jest.fn()
+  const s2 = jest.fn()
+
+  const p1 = cache.get('foo', { testing: 'test1' }, aborter1.signal, s1)
+  //const p2 = cache.get('foo', { testing: 'test2' }, undefined, s2)
+  console.log('test2')
+  await p1 //await Promise.all([p1, p2])
+  expect(s1).toHaveBeenCalledWith('working...')
+  expect(s2).toHaveBeenCalledWith('working...')
 })


### PR DESCRIPTION
I felt sufficiently disturbed by https://github.com/GMOD/jbrowse-components/pull/1142 that I decided to see what it might look like to add status reporting to this cache system

I thought it didn't seem too bad and resulted in something that was sort of similar to the aggregate abort concept

Not yet tested in the context of jb2 status reporting