### PR TITLE
Avoid evicting cache entry if settled

### DIFF
--- a/src/AbortablePromiseCache.ts
+++ b/src/AbortablePromiseCache.ts
@@ -173,7 +173,7 @@ export default class AbortablePromiseCache<T, U> {
     const cacheEntry = this.cache.get(key)
 
     if (cacheEntry) {
-      if (cacheEntry.aborted) {
+      if (cacheEntry.aborted && !cacheEntry.settled) {
         // if it's aborted but has not realized it yet, evict it and redispatch
         this.evict(key, cacheEntry)
         return this.get(key, data, signal, statusCallback)


### PR DESCRIPTION
If the cacheEntry is aborted and settled, it still evicts it here, which I think is undesired behavior. It should avoid evicting here if it was already settled