### PR TITLE
Fix babel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prebuild": "npm run clean",
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc",
-    "build:js": "babel src -d dist",
+    "build:js": "babel src -d dist --extensions \".ts,.tsx\"",
     "watch": "npm-watch",
     "prepublishOnly": "npm run lint && npm test && npm run build",
     "postpublish": "git push --tags origin master"


### PR DESCRIPTION
My attempts at doing `yarn link` and `yarn build:js --watch` were being thwarted because the babel build was actually doing nothing

The current build was actually only working because yarn tsc was generating the browserified output

An alternative to this PR could be to remove the babel step from the build, but just keep babel for the test
