### PR TITLE
Make `get` possibly return undefined

### DIFF
--- a/src/AbortablePromiseCache.ts
+++ b/src/AbortablePromiseCache.ts
@@ -5,7 +5,7 @@ import AggregateStatusReporter from './AggregateStatusReporter'
 type Cache<U> = {
   delete: (key: string) => void
   keys: () => Iterator<string>
-  get: (key: string) => U
+  get: (key: string) => U | undefined
   set: (key: string, val: U) => void
   has: (key: string) => boolean
 }
@@ -198,7 +198,7 @@ export default class AbortablePromiseCache<T, U> {
     // if we got here, it is not in the cache. fill.
     this.fill(key, data, signal, statusCallback)
     return AbortablePromiseCache.checkSinglePromise(
-      this.cache.get(key).promise,
+      this.cache.get(key)!.promise,
       signal,
     )
   }


### PR DESCRIPTION
`get` in the `Cache` should possibly return `undefined`, if the key is not in the cache. You can see here that its usage in the code confirms this:

https://github.com/rbuels/abortable-promise-cache/blob/68803e71ce7bfa13c0a2755e82ba6c203def290c/src/AbortablePromiseCache.ts#L173-L175

This fix also makes it possible to use the latest `quick-lru` in TypeScript with `abortable-promise-cache`, since without this fix the types of `get` clash.